### PR TITLE
feat: Constants values as dynamic function call

### DIFF
--- a/siftlog/__init__.py
+++ b/siftlog/__init__.py
@@ -30,6 +30,8 @@ class SiftLog(logging.LoggerAdapter):
 
         kwargs[self.LEVEL] = logging.getLevelName(level)
 
+        self._evaluate_dynamic_values()
+
         # append the optional constants defined on initialization
         kwargs.update(self._constants)
 
@@ -55,6 +57,11 @@ class SiftLog(logging.LoggerAdapter):
             )
 
         return payload
+
+    def _evaluate_dynamic_values(self):
+        for k, v in self._constants.items():
+            if hasattr(v, '__call__'):
+                self._constants[k] = v()
 
     def to_json(self, data):
         return json.dumps(data)

--- a/siftlog/tests/test_log.py
+++ b/siftlog/tests/test_log.py
@@ -20,6 +20,17 @@ class TestLogger(unittest.TestCase):
         self.assertEquals(res["pid"], 12345)
         self.assertEquals(res["app"], "APP NAME")
 
+    def test_arbitrary_dynamic_constants(self):
+        func = lambda: "FUNC_RESULT"
+
+        logger = SiftLog(self.core_logger, pid=12345, app="APP NAME", func=func)
+
+        res = json.loads(logger._get_log_stmt(logging.INFO, None))
+
+        self.assertEquals(res["pid"], 12345)
+        self.assertEquals(res["app"], "APP NAME")
+        self.assertEquals(res["func"], "FUNC_RESULT")
+
     def test_simple_log_statement(self):
         stmt = "simple log statement"
         res = json.loads(self.sift_logger._get_log_stmt(logging.DEBUG, stmt))


### PR DESCRIPTION
Look at that feat

I had a issue to track the "journey" of a user. And i need to track a behavior of my program tracking by specífic user id.
In that example, i used a simple lambda func to demostrate a evaluate the "user id". It could be a call of thread local. Eg:

```python
from threading import local

_thread_locals = local()

def get_user_id() -> str:
    return getattr(_thread_locals, "user_id", None)
```

And the example of declaration of logger it wold be:

```python
logger = logger = SiftLog(self.core_logger, pid=12345, app="APP NAME", user_id=get_user_id)
```

What do you think?